### PR TITLE
Write response from DevOps in addCommentToPR

### DIFF
--- a/GPTPullRequestReview/src/pr.ts
+++ b/GPTPullRequestReview/src/pr.ts
@@ -36,7 +36,7 @@ export async function addCommentToPR(fileName: string, comment: string, httpsAge
     console.log(`Response status: ${response.status}`);
     console.log(`Response data: ${JSON.stringify(responseData)}`);
 
-    if (response.status !== 201) {
+    if (response.status !== 200) {
       throw new Error(`Failed to add comment to PR. Status: ${response.status}, Response: ${JSON.stringify(responseData)}`);
     }
 

--- a/GPTPullRequestReview/src/pr.ts
+++ b/GPTPullRequestReview/src/pr.ts
@@ -21,14 +21,29 @@ export async function addCommentToPR(fileName: string, comment: string, httpsAge
 
   const prUrl = `${tl.getVariable('SYSTEM.TEAMFOUNDATIONCOLLECTIONURI')}${tl.getVariable('SYSTEM.TEAMPROJECTID')}/_apis/git/repositories/${tl.getVariable('Build.Repository.Name')}/pullRequests/${tl.getVariable('System.PullRequest.PullRequestId')}/threads?api-version=5.1`
 
-  await fetch(prUrl, {
-    method: 'POST',
-    headers: { 'Authorization': `Bearer ${tl.getVariable('SYSTEM.ACCESSTOKEN')}`, 'Content-Type': 'application/json' },
-    body: stringifiedBody,
-    agent: httpsAgent
-  });
+  try {
+    const response = await fetch(prUrl, {
+      method: 'POST',
+      headers: { 
+        'Authorization': `Bearer ${tl.getVariable('SYSTEM.ACCESSTOKEN')}`, 
+        'Content-Type': 'application/json' 
+      },
+      body: stringifiedBody,
+      agent: httpsAgent
+    });
 
-  console.log(`New comment added.`, stringifiedBody);
+    const responseData = await response.json();
+    console.log(`Response status: ${response.status}`);
+    console.log(`Response data: ${JSON.stringify(responseData)}`);
+
+    if (response.status !== 201) {
+      throw new Error(`Failed to add comment to PR. Status: ${response.status}, Response: ${JSON.stringify(responseData)}`);
+    }
+
+    console.log(`New comment added successfully.`, stringifiedBody);
+  } catch (error) {
+    console.error('Error adding comment to PR:', error);
+  }
 }
 
 export async function deleteExistingComments(httpsAgent: Agent) {


### PR DESCRIPTION
Everything with this extension works properly except the comments don't get added to the PR (even though the output of the extension says they were added).  This change is to show the response from the POST to DevOps.

It also adds a try/catch so if the POST does not return a 200 we show that.